### PR TITLE
7743 - Allow buttons to use className instead of buttonSize

### DIFF
--- a/FinsembleDialogButton/FinsembleDialogButton.jsx
+++ b/FinsembleDialogButton/FinsembleDialogButton.jsx
@@ -17,6 +17,7 @@ export default class FinsembleDialogButton extends React.Component {
 		//If you're unfamiliar with this syntax, it's equivalent to
 		//let classes='fsbl-button-' + size;
 		let classes=`fsbl-button-${size}`;
+		//Also allow for className to be used in case size is unimportant;
 		classes += ' ' + this.props.className;
 		return (<FinsembleButton className={classes} {...this.props} buttonType="Dialog">
 			{this.props.children}

--- a/FinsembleDialogButton/FinsembleDialogButton.jsx
+++ b/FinsembleDialogButton/FinsembleDialogButton.jsx
@@ -17,6 +17,7 @@ export default class FinsembleDialogButton extends React.Component {
 		//If you're unfamiliar with this syntax, it's equivalent to
 		//let classes='fsbl-button-' + size;
 		let classes=`fsbl-button-${size}`;
+		classes += ' ' + this.props.className;
 		return (<FinsembleButton className={classes} {...this.props} buttonType="Dialog">
 			{this.props.children}
 		</FinsembleButton>);


### PR DESCRIPTION
With Brad's help, made it so that buttons in dialogs can accept className designations. Button classes in the seed are no longer reliant on button size, and this allows users to skirt the buttonSize parameter. This should preserve backward compatibility with those still using buttonSize.