### PR TITLE
Updated React dependancy to 16.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-0": "^6.16.0",
     "babel-preset-stage-1": "^6.16.0",
-    "react": "^15.3.2",
+    "react": "^16.8.3",
     "react-beautiful-dnd": "^4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Resolves issue 12183

Description of changes
-Updated React to 16.8.3 or later (^)

Description of Testing Done
-Updated seed and Finsemble both seem to be working when manually going through the items in the finsemble-react-controls. No console errors or visual regressions.

To Test
-Open Finsemble seed and make sure to link to the locally cloned finsemble-react-tools. Test each item works the same as before, toolbar, buttons etc.