### PR TITLE
Fix 15467 Apps Menu requires multiples clicks to launch

### DIFF
--- a/FinsembleButton/FinsembleButton.jsx
+++ b/FinsembleButton/FinsembleButton.jsx
@@ -123,7 +123,6 @@ export default class Button extends React.Component {
 		//If the click action has been invalidated (because the user clicked the menu Launcher while the menu was open), we allow subsequent clicks to open the menu.
 		if (!this.openMenuOnClick) {
 			this.openMenuOnClick = true;
-			return;
 		}
 		let self = this;
 		//Params for the dialogManager.


### PR DESCRIPTION
Fix #15467

[Kanbanize Link](https://chartiq.kanbanize.com/ctrl_board/18/cards/15467/details/)

**Changes**

- Remove unnecessary return line

**Testing**
1. Checkout and build `15467-apps-menu`
1. Navigate to seed and run `npm link @chartiq/finsemble-react-controls`
1. Launch seed and navigate to the Apps section of the toolbar
1. Click on `Apps` 
1. If Drop-down spawns, click on Desktop (outside of drop-down and off toolbar)
1. Click `Apps` again

- [ ] Menu should spawn after first click