### PR TITLE
15695 Move overflow menu building to toolbar resize

### DIFF
--- a/FinsembleToolbarSection/FinsembleToolbarSection.jsx
+++ b/FinsembleToolbarSection/FinsembleToolbarSection.jsx
@@ -203,6 +203,7 @@ export default class FinsembleToolbarSection extends React.Component {
      * @memberof FinsembleToolbarSection
      */
 	saveButtonsToOverflowStore(e, self) {
+		if (!self.state.overflowStore || !self.state.overflowStore.setValue) return;
 		self.state.overflowStore.setValue({ field: 'clickChannel', value: self.state.clickChannel });
 		function makeButtonsSafeForRouter(overflow) {
 			return overflow.map((el) => {
@@ -275,6 +276,8 @@ export default class FinsembleToolbarSection extends React.Component {
 			self.setState({
 				overflow: overflow,
 				minOverflowIndex: (overflow[0] ? overflow[0].index : minOverflowIndex)
+			}, () => {
+				self.saveButtonsToOverflowStore(null, self);
 			});
 		}
 	}
@@ -539,6 +542,8 @@ export default class FinsembleToolbarSection extends React.Component {
 					self.initialLoad = true;
 				});
 				store.addListener({ field: 'pins' }, self.processPins);
+			}, () => {
+				self.saveButtonsToOverflowStore(null, self);
 			});
 		}
 

--- a/FinsembleToolbarSection/FinsembleToolbarSection.jsx
+++ b/FinsembleToolbarSection/FinsembleToolbarSection.jsx
@@ -142,6 +142,7 @@ export default class FinsembleToolbarSection extends React.Component {
 	 * @param {*} e
 	 */
 	handleResize(e) {
+		this.saveButtonsToOverflowStore(e, this);
 		this.setState({ minOverflowIndex: DEFAULT_MINIMUM_OVERFLOW, overflow: [] });
 	}
 
@@ -572,7 +573,7 @@ export default class FinsembleToolbarSection extends React.Component {
 					var comps = [];
 					// render the overflow component
 					if (index == self.state.minOverflowIndex) {
-						comps.push(<OverflowComponent beforeClick={function (e) { self.saveButtonsToOverflowStore(e, self); }} {...self.state.overflowMenuProps} key={'overflow' + index} />);
+						comps.push(<OverflowComponent {...self.state.overflowMenuProps} key={'overflow' + index} />);
 					}
 					// render the rest of the components hidden
 					comps.push(<div key={index} style={{ display: 'none' }}>{item}</div>);


### PR DESCRIPTION
[Kanban card](https://chartiq.kanbanize.com/ctrl_board/18/cards/15695/details/)

**Changes**
* Moved beforeClick logic of overflow menu to recalculate on resize

**Steps to reproduce**
1. Run finsemble
1. Undock toolbar and move near the top/bottom edge of a monitor (do not dock)
1. Pin a number of apps (5-6+) (add some ad-hoc components if you have to)
1. Resize the toolbar so pins are moved into the overflow menu
1. [ ] Opening the overflow menu near a monitor edge does not cut off any menu contents
1. Keep resizing and moving/removing items from the overflow menu
1. [ ] Continuing to open the menu near monitor edges after pin updates does not cause the menu to be cut off

**NOTE**: When reloading the component with Ctrl + R, there are occasional bounds issues with the toolbar/menu. These are outside the scope of the ticket and potentially related to larger problems with setBounds which are being addressed external to this issue. In a normal use case, the problems with the menu appearing in weird places has been fixed. There are occasions where the menu can open in the wrong place, but as far I could tell, this is only when reloading a component without going through Finsemble (Ctrl + R).