### PR TITLE
fix: #id 15917 hide overflow menu onClick

### DIFF
--- a/FinsembleOverflowMenu/FinsembleOverflowMenu.jsx
+++ b/FinsembleOverflowMenu/FinsembleOverflowMenu.jsx
@@ -91,6 +91,7 @@ export default class FinsembleOverflowMenu extends React.Component {
 	onClick(e, buttonIndex) {
 		//The props of the MenuItem itself are passed to the Label as menuItemProps.
 		FSBL.Clients.RouterClient.transmit(this.state.clickChannel, { index: buttonIndex });
+		FSBL.Clients.WindowClient.finsembleWindow.hide();
 	}
 
 	componentWillMount() {


### PR DESCRIPTION
fix: #id 15194

Kanban [link](https://chartiq.kanbanize.com/ctrl_board/18/cards/15917/details/)

**Description of change**
Add the function to hide the overflow menu onClick

**Description of testing**
1. Pull down this branch, test along with 3.12.0 finsemble seed. Make sure you're linked
1. Pin some components on the toolbar including the Notepad and shrink the toolbar so the overflow menu shows up
1. Expand the overflow menu, click on the notepad component, make sure the notepad is spawn and the overflow menu closes