### PR TITLE
fix: #id 15701 Fix the bug where a user needs to double click the menu button to bring up the menu

### DIFF
--- a/FinsembleButton/FinsembleButton.jsx
+++ b/FinsembleButton/FinsembleButton.jsx
@@ -161,9 +161,9 @@ export default class Button extends React.Component {
 						self.openMenuOnClick = openMenuOnClick;
 						console.log('LaunchMenu Post Blur', self.openMenuOnClick, boundingBox, position);
 					});
-					finWindow.removeEventListener('blurred', onMenuBlurred);
+					finWindow.removeEventListener('hidden', onMenuBlurred);
 				};
-				finWindow.addEventListener('blurred', onMenuBlurred);
+				finWindow.addEventListener('hidden', onMenuBlurred);
 
 				//Our appLauncher is listening on this channel for items to populate it.
 				//@todo move this into the AppLauncherButton code.


### PR DESCRIPTION
fix: #id 15701

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/15701/details/)

**Description of change**
* Listen to the 'hidden' instead of 'blurred' event on the toolbar menu

**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. Checkout this branch, test along with planned/4.0.0 seed branch
1. Launch finsemble
1. Test clicking on menus on a floating titlebar and a docked titlebar
1. Test clicking away from menus, clicking on menus after pressing 'esc' to hide the menu, clicking on menus right after spawning a component
1. [x] menu opens every time user clicks on the menu button and it doesn't require a second click to bring up the menu
